### PR TITLE
Support IDA 9.0.240925

### DIFF
--- a/amie.py
+++ b/amie.py
@@ -351,7 +351,7 @@ class AMIE(ida_idaapi.plugin_t, ida_idp.IDP_Hooks, ida_kernwin.UI_Hooks):
             self.arch = AArch32()
 
     def plugin_loaded(self, plugin_info):
-        if plugin_info.name == "Hex-Rays Decompiler":
+        if plugin_info.name.startswith("Hex-Rays Decompiler"):
             if ida_hexrays.init_hexrays_plugin():
                 self.hexrays_support = True
                 ida_hexrays.install_hexrays_callback(self.hxe_callback)


### PR DESCRIPTION
In IDA 9.0.240925 plugin_info.name == "Hex-Rays Decompiler Options" instead of plugin_info.name == "Hex-Rays Decompiler", so the fix is just to use .startswith("Hex-Rays Decompiler")